### PR TITLE
fix: swap positions of Expanded widget

### DIFF
--- a/lib/component/today_banner.dart
+++ b/lib/component/today_banner.dart
@@ -45,10 +45,10 @@ class _TodayBannerState extends State<TodayBanner> {
                 style: textStyle,
               ),
             ),
-            InkWell(
-              onTap: widget.onGoToToday, // 콜백 함수 호출
-              child: const Expanded(
-                child: Text(
+            Expanded(
+              child: InkWell(
+                onTap: widget.onGoToToday,
+                child: const Text(
                   textAlign: TextAlign.center,
                   '오늘로 돌아가기',
                   style: textStyle,

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,9 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:riverpod_todo_with_dashboard/database/drift_database.dart';
 import 'package:riverpod_todo_with_dashboard/screens/login_screens/analytics_screen.dart';
 import 'package:riverpod_todo_with_dashboard/screens/login_screens/on_day_selected_page.dart';
-import 'package:riverpod_todo_with_dashboard/database/drift_database.dart';
 
 import '../component/online_calendar.dart';
 import '../consts/colors.dart';
@@ -163,13 +163,13 @@ class ExitAlertDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text(
+      title: const Text(
         '앱 종료',
         style: TextStyle(
           color: black,
         ),
       ),
-      content: Text(
+      content: const Text(
         '앱을 종료하시겠습니까?',
         style: TextStyle(
           color: black,
@@ -178,7 +178,7 @@ class ExitAlertDialog extends StatelessWidget {
       actions: <Widget>[
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: Text(
+          child: const Text(
             '취소',
             style: TextStyle(
               color: black,
@@ -187,7 +187,7 @@ class ExitAlertDialog extends StatelessWidget {
         ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(true),
-          child: Text(
+          child: const Text(
             '종료',
             style: TextStyle(
               color: black,
@@ -231,26 +231,26 @@ class _TodayBannerState extends State<TodayBanner> {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            InkWell(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const AnalyticsScreen(),
-                  ),
-                );
-              }, // 콜백 함수 호출
-              child: const Expanded(
-                child: Text(
+            Expanded(
+              child: InkWell(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const AnalyticsScreen(),
+                    ),
+                  );
+                },
+                child: const Text(
                   '활동 내역 리포트 보기',
                   style: textStyle,
                 ),
               ),
             ),
-            InkWell(
-              onTap: widget.onGoToToday, // 콜백 함수 호출
-              child: const Expanded(
-                child: Text(
+            Expanded(
+              child: InkWell(
+                onTap: widget.onGoToToday,
+                child: const Text(
                   '오늘로 돌아가기',
                   style: textStyle,
                 ),


### PR DESCRIPTION
잘못 사용된 `Expanded` 위젯의 위치들을 변경한 코드입니다. 저랑 lint rule 이 달라서 코드 컨벤션이 맞지 않는 부분이 있으니 머지하진 마시고 참고용으로만 봐주세요!

추가로 `return Expanded` 로 `Expanded` 위젯을 반환하는 위젯들이 있는데, 이는 권장되지 않는 방식입니다. `Flexible` 과 `Expanded` 는 `Column` 이나 `Row` 같은 `Flex` 위젯 내에서만 사용해야 하기에 `build` 메소드에서 이를 반환할 경우 사용하는 위젯에서 헷갈리거나 실수할 위험이 있습니다. 

이를 방지하기 위한 좋은 패턴으로는, 모양을 결정하는 component widget 과 위치와 크기를 결정하는 layout widget 을 분리하는 방법이 있습니다. 

플러터 공식 문서에서도 Layout 위젯은 별도의 카탈로그로 구분하고 있습니다. (https://docs.flutter.dev/ui/widgets/layout)

정말 플러터 개발자로 계속 하고 싶으시거나, 깊은 이해를 하고 싶으시다면 https://docs.flutter.dev/ui/layout/constraints 이 문서를 공부해보는걸 추천 드립니다!